### PR TITLE
fix: verify that metal3 is supported

### DIFF
--- a/mistralrs-core/src/attention.rs
+++ b/mistralrs-core/src/attention.rs
@@ -148,49 +148,59 @@ fn supports_attn_softmax() -> Result<bool> {
         let version = if cache != usize::MAX {
             cache
         } else {
-            // echo "__METAL_VERSION__" | xcrun -sdk macosx metal -E -x metal -P -
-
-            use std::process::{Command, Stdio};
-
-            // Create the `echo` command and pipe its output into `xcrun`
-            let mut echo = Command::new("echo")
-                .arg("__METAL_VERSION__")
-                .stdout(Stdio::piped())
-                .spawn()
-                .expect("Failed to start echo command");
-
-            echo.wait()?;
-
-            // Run the `xcrun` command, taking input from the `echo` command's output
-            let output = Command::new("xcrun")
-                .arg("-sdk")
-                .arg("macosx")
-                .arg("metal")
-                .arg("-E")
-                .arg("-x")
-                .arg("metal")
-                .arg("-P")
-                .arg("-")
-                .stdin(echo.stdout.unwrap())
-                .output()
-                .expect("Failed to run xcrun command");
-
-            // Handle the output
-            if output.status.success() {
-                let version = String::from_utf8_lossy(&output.stdout)
-                    .split('\n')
-                    .nth(1)
-                    .unwrap()
-                    .trim()
-                    .to_string()
-                    .parse::<usize>()
-                    .unwrap();
-                METAL_VERSION_CACHE.store(version, Ordering::Relaxed);
-                version
+            // TODO: It can only verify that metal3 is supported, but cannot obtain the specific version
+            let device = metal::Device::system_default().unwrap();
+            if device.supports_family(metal::MTLGPUFamily::Metal3) {
+                METAL_VERSION_CACHE.store(310, Ordering::Relaxed);
+                310
             } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                panic!("Error:\n{}", stderr);
+                panic!("Error: this device does not support metal3.");
             }
+
+            // TODO: Cannot be used within an App Sandbox
+            // // echo "__METAL_VERSION__" | xcrun -sdk macosx metal -E -x metal -P -
+
+            // use std::process::{Command, Stdio};
+
+            // // Create the `echo` command and pipe its output into `xcrun`
+            // let mut echo = Command::new("echo")
+            //     .arg("__METAL_VERSION__")
+            //     .stdout(Stdio::piped())
+            //     .spawn()
+            //     .expect("Failed to start echo command");
+
+            // echo.wait()?;
+
+            // // Run the `xcrun` command, taking input from the `echo` command's output
+            // let output = Command::new("xcrun")
+            //     .arg("-sdk")
+            //     .arg("macosx")
+            //     .arg("metal")
+            //     .arg("-E")
+            //     .arg("-x")
+            //     .arg("metal")
+            //     .arg("-P")
+            //     .arg("-")
+            //     .stdin(echo.stdout.unwrap())
+            //     .output()
+            //     .expect("Failed to run xcrun command");
+
+            // // Handle the output
+            // if output.status.success() {
+            //     let version = String::from_utf8_lossy(&output.stdout)
+            //         .split('\n')
+            //         .nth(1)
+            //         .unwrap()
+            //         .trim()
+            //         .to_string()
+            //         .parse::<usize>()
+            //         .unwrap();
+            //     METAL_VERSION_CACHE.store(version, Ordering::Relaxed);
+            //     version
+            // } else {
+            //     let stderr = String::from_utf8_lossy(&output.stderr);
+            //     panic!("Error:\n{}", stderr);
+            // }
         };
         // Attn softmax is only supported for metal >= 310
         Ok(version >= 310)


### PR DESCRIPTION
The mistralrs-core attention.rs: xcrun command cannot be used within an App Sandbox, change to using verification metal3, but cannot obtain the specific version.